### PR TITLE
fix(logstash): take into account the JAVA_OPTS

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -8,4 +8,8 @@ export ELASTICSEARCH_HOST=$url
 export ELASTICSEARCH_USER=$user
 export ELASTICSEARCH_PASSWORD=$pass
 
+export LS_JAVA_OPTS="$JAVA_OPTS"
+unset JAVA_OPTS
+unset JAVA_TOOL_OPTIONS
+
 $APP_PATH/logstash/logstash-$LOGSTASH_VERSION/bin/logstash $*


### PR DESCRIPTION
I deployed it in the app `test-logstash`. First lines of the deployment logs:

```
2021-06-10 12:28:48.574710690 +0200 CEST [manager] container [web-1] (60c1e94d987e0b5f5414f4d0) started with the command 'bin/logstash -f logstash.conf'
2021-06-10 12:28:48.598350491 +0200 CEST [web-1] Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them.
2021-06-10 12:29:00.198359622 +0200 CEST [web-1] Sending Logstash logs to /app/logstash/logstash-6.8.5/logs which is now configured via log4j2.properties
2021-06-10 12:29:00.445112382 +0200 CEST [web-1] [2021-06-10T10:29:00,444][INFO ][logstash.setting.writabledirectory] Creating directory {:setting=>"path.dead_letter_queue", :path=>"/app/logstash/logstash-6.8.5/data/dead_letter_queue"}
2021-06-10 12:29:00.431861448 +0200 CEST [web-1] [2021-06-10T10:29:00,429][INFO ][logstash.setting.writabledirectory] Creating directory {:setting=>"path.queue", :path=>"/app/logstash/logstash-6.8.5/data/queue"}
2021-06-10 12:29:00.715423361 +0200 CEST [web-1] [2021-06-10T10:29:00,715][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
2021-06-10 12:29:00.721409145 +0200 CEST [web-1] [2021-06-10T10:29:00,721][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"6.8.5"}
2021-06-10 12:29:00.742146315 +0200 CEST [web-1] [2021-06-10T10:29:00,741][INFO ][logstash.agent           ] No persistent UUID file found. Generating new UUID {:uuid=>"38dfe4be-b9e3-4839-8f45-cc0401333e07", :path=>"/app/logstash/logstash-6.8.5/data/uuid"}
[...]
```

The offending line are not displayed anymore.

Fix #3