### PR TITLE
Upgrade buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ indent() {
   sed 's/^/       /'
 }
 
-LOGSTASH_VERSION=${LOGSTASH_VERSION:-6.8.21}
+LOGSTASH_VERSION=${LOGSTASH_VERSION:-9.0.1}
 
 BUILDPACK_PATH=$(dirname $(readlink -f $0))/../
 

--- a/bin/compile
+++ b/bin/compile
@@ -44,12 +44,13 @@ export PATH="${PATH}:${BUILD_DIR}/bin"
 echo "Installing plugins" | indent
 
 # Always install logstash-output-opensearch
-"${BUILD_DIR}/bin/logstash-plugin-install" "logstash-output-opensearch"
+echo "Installing plugin logstash-output-opensearch" | indent
+bin/logstash-plugin install "logstash-output-opensearch"
 
 # Install other plugins:
 for plugin in $(echo $LOGSTASH_PLUGINS | sed "s/,/ /g") ; do
   echo "Installing plugin $plugin" | indent
-  "${BUILD_DIR}/bin/logstash-plugin" install "${plugin}" | indent
+  bin/logstash-plugin install "${plugin}" | indent
 done
 
 echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -43,14 +43,13 @@ export PATH="${PATH}:${BUILD_DIR}/bin"
 
 echo "Installing plugins" | indent
 
-cd $BUILD_DIR/logstash/logstash-$LOGSTASH_VERSION
+# Always install logstash-output-opensearch
+bin/logstash-plugin-install "logstash-output-opensearch"
 
+# Install other plugins:
 for plugin in $(echo $LOGSTASH_PLUGINS | sed "s/,/ /g") ; do
   echo "Installing plugin $plugin" | indent
   bin/logstash-plugin install $plugin | indent
 done
-
-mkdir -p $BUILD_DIR/bin
-cp $BUILDPACK_PATH/bin/logstash $BUILD_DIR/bin/logstash
 
 echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -44,12 +44,12 @@ export PATH="${PATH}:${BUILD_DIR}/bin"
 echo "Installing plugins" | indent
 
 # Always install logstash-output-opensearch
-bin/logstash-plugin-install "logstash-output-opensearch"
+"${BUILD_DIR}/bin/logstash-plugin-install" "logstash-output-opensearch"
 
 # Install other plugins:
 for plugin in $(echo $LOGSTASH_PLUGINS | sed "s/,/ /g") ; do
   echo "Installing plugin $plugin" | indent
-  bin/logstash-plugin install $plugin | indent
+  "${BUILD_DIR}/bin/logstash-plugin" install "${plugin}" | indent
 done
 
 echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -21,8 +21,25 @@ fi
 curl $URL -L --silent -o /tmp/logstash.tar.gz
 
 echo "Extracting logstash" | indent
-mkdir -p $BUILD_DIR/logstash
 tar -xf /tmp/logstash.tar.gz -C $BUILD_DIR/logstash
+
+# Put user-provided config files aside:
+if [ -d "${BUILD_DIR}/config" ]; then
+  mv "${BUILD_DIR}/config" "${BUILD_DIR}/user_config" 2> /dev/null
+fi
+
+# Copy default config files:
+mv "${BUILD_DIR}/logstash-${LOGSTASH_VERSION}/"* "${BUILD_DIR}/"
+rmdir "${BUILD_DIR}/logstash-${LOGSTASH_VERSION}"
+
+# Put back user-provided config:
+if [ -d "${BUILD_DIR}/user_config" ]; then
+  mv "${BUILD_DIR}/user_config/"* "${BUILD_DIR}/config/" 2> /dev/null
+  rmdir "${BUILD_DIR}/user_config" 2> /dev/null
+fi
+
+export PATH="${PATH}:${BUILD_DIR}/bin"
+
 
 echo "Installing plugins" | indent
 

--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ fi
 curl $URL -L --silent -o /tmp/logstash.tar.gz
 
 echo "Extracting logstash" | indent
-tar -xf /tmp/logstash.tar.gz -C $BUILD_DIR/logstash
+tar -xf /tmp/logstash.tar.gz -C $BUILD_DIR
 
 # Put user-provided config files aside:
 if [ -d "${BUILD_DIR}/config" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ if [ ${LOGSTASH_VERSION:0:1} = "6" ]
 then
   URL=https://artifacts.elastic.co/downloads/logstash/logstash-$LOGSTASH_VERSION.tar.gz
 else
-  URL=https://artifacts.elastic.co/downloads/logstash/logstash-$LOGSTASH_VERSION-linux-x86_64.tar.gz
+  URL=https://artifacts.elastic.co/downloads/logstash/logstash-oss-$LOGSTASH_VERSION-linux-x86_64.tar.gz
 fi
 curl $URL -L --silent -o /tmp/logstash.tar.gz
 

--- a/bin/release
+++ b/bin/release
@@ -1,2 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+cat << EOF
+---
+config_vars:
+  PATH: "/app/bin:/usr/local/bin:/usr/bin:/bin"
+default_process_types:
+  web: /app/bin/logstash -f logstash.conf
+EOF


### PR DESCRIPTION
- Defaults to Logstash `9.0.1`
- Defaults to using the bundled JDK (no more dependency to `buildpack-jvm-common`)
- Allows user to bring their own config files (in the `config` directory)
- Always installs `logstash-output-opensearch` plugin