### PR TITLE
chore(logstash): now defaults to Logstash 9.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,11 @@ This buildpack manage the installation of
 It has been designed to work on [Scalingo](https://scalingo.com/), but it should
 work on any other platform that support buildpacks.
 
-Default version: 6.8.21
+Default version: 9.2.4
 
 Please follow our [documentation
 page](https://doc.scalingo.com/platform/getting-started/getting-started-with-elk#logstash)
 about the ELK stack to use this buildpack.
-
-## Prerequisites
-
-This buildpack assume that java is already installed with the correct version.
 
 ## Configuration
 
@@ -23,17 +19,3 @@ To configure the buildpack you can use the following environment variables:
 * `LOGSTASH_VERSION`: Define which version of Logstash will be installed
 * `LOGSTASH_PLUGINS`: Comma separated list of plugins which needs to be
   installed. [List of plugins](https://github.com/logstash-plugins)
-
-## Installation path
-
-The elasticsearch binary will be available at
-`logstash/logstash-$LOGSTASH_VERSION/bin/logstash`.
-
-You can also use the wrapper present in this buildpack which will do two
-things:
-* Use the `LOGSTASH_VERSION` environment variable to generate the path
-* Split the `ELASTICSEARCH_URL` variable into three:
-  * `ELASTICSEARCH_HOST`
-  * `ELASTICSEARCH_USER`
-  * `ELASTICSEARCH_PASSWORD`
-

--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ indent() {
   sed 's/^/       /'
 }
 
-LOGSTASH_VERSION=${LOGSTASH_VERSION:-9.0.2}
+LOGSTASH_VERSION=${LOGSTASH_VERSION:-9.2.4}
 
 BUILDPACK_PATH=$(dirname $(readlink -f $0))/../
 

--- a/bin/logstash
+++ b/bin/logstash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 eval $(echo $ELASTICSEARCH_URL | sed -r 's/(https?:\/\/)(([^:]*):([^:]*)@){0,1}(.*)/url=\1\5 \nuser=\3 \npass=\4/')
-LOGSTASH_VERSION=${LOGSTASH_VERSION:-6.8.21}
+LOGSTASH_VERSION=${LOGSTASH_VERSION:-9.2.4}
 APP_PATH=$(dirname $(readlink -f $0))/../
 
 export ELASTICSEARCH_HOST=$url


### PR DESCRIPTION
Related to #16 

Successfully tested here: https://fku-logstash.osc-fr1.scalingo.io/