### PR TITLE
chore(logstash): update Logstash to 7.17.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,24 @@ This buildpack manage the installation of
 It has been designed to work on [Scalingo](https://scalingo.com/), but it should
 work on any other platform that support buildpacks.
 
-Default version: 6.8.21
-
 Please follow our [documentation
 page](https://doc.scalingo.com/platform/getting-started/getting-started-with-elk#logstash)
 about the ELK stack to use this buildpack.
 
-## Prerequisites
-
-This buildpack assume that java is already installed with the correct version.
 
 ## Configuration
 
 To configure the buildpack you can use the following environment variables:
 
-* `LOGSTASH_VERSION`: Define which version of Logstash will be installed
-* `LOGSTASH_PLUGINS`: Comma separated list of plugins which needs to be
-  installed. [List of plugins](https://github.com/logstash-plugins)
+* `LOGSTASH_VERSION`\
+  Allows to specify the version of Logstash to install
+* `LOGSTASH_PLUGINS`\
+  A comma separated list of plugin names to install.
+  [List of plugins](https://github.com/logstash-plugins)
 
 ## Installation path
 
-The elasticsearch binary will be available at
+The elasticsearch binary is available at
 `logstash/logstash-$LOGSTASH_VERSION/bin/logstash`.
 
 You can also use the wrapper present in this buildpack which will do two
@@ -36,4 +33,3 @@ things:
   * `ELASTICSEARCH_HOST`
   * `ELASTICSEARCH_USER`
   * `ELASTICSEARCH_PASSWORD`
-

--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ indent() {
   sed 's/^/       /'
 }
 
-LOGSTASH_VERSION=${LOGSTASH_VERSION:-6.8.21}
+LOGSTASH_VERSION=${LOGSTASH_VERSION:-7.17.29}
 
 BUILDPACK_PATH=$(dirname $(readlink -f $0))/../
 

--- a/bin/logstash
+++ b/bin/logstash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 eval $(echo $ELASTICSEARCH_URL | sed -r 's/(https?:\/\/)(([^:]*):([^:]*)@){0,1}(.*)/url=\1\5 \nuser=\3 \npass=\4/')
-LOGSTASH_VERSION=${LOGSTASH_VERSION:-6.8.21}
+LOGSTASH_VERSION=${LOGSTASH_VERSION:-7.17.29}
 APP_PATH=$(dirname $(readlink -f $0))/../
 
 export ELASTICSEARCH_HOST=$url


### PR DESCRIPTION
Logstash `7.17.29` is the latest version compatible with Elasticsearch `7.10.2`.
(see https://www.elastic.co/fr/support/matrix#matrix_compatibility)

Tested here: https://fku-logstash-es7.osc-st-fr1.apps.st-sc.fr/